### PR TITLE
Support Elasticsearch 2.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,8 +34,19 @@ elasticsearch_cluster_name: 'elasticsearch'
 elasticsearch_node_name: ''
 
 
+# .. envvar:: elasticsearch_node_rack
+#
+# Add a node attribute ``rack`` which can be used for shard allocation
+# awareness.
 elasticsearch_node_rack: 'nicerack'
-elasticsearch_node_max_local_storage_nodes: 50
+
+
+# .. envvar:: elasticsearch_node_max_local_storage_nodes
+#
+# Number of nodes per server which can share the same data path. For more
+# information see the upstream documentation of `max_local_storage_nodes
+# <https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-node.html#max-local-storage-nodes>`.
+elasticsearch_node_max_local_storage_nodes: 1
 
                                                                    # ]]]
 # Index configuration [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,8 +34,6 @@ elasticsearch_cluster_name: 'elasticsearch'
 elasticsearch_node_name: ''
 
 
-elasticsearch_node_master: true
-elasticsearch_node_data: true
 elasticsearch_node_rack: 'nicerack'
 elasticsearch_node_max_local_storage_nodes: 50
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,9 @@
 
 # .. envvar:: elasticsearch_version
 #
-# Elasticsearch version. To install the latest minor release, only supply 1.x.
+# Elasticsearch version. Supported are the 1.x.y and 2.x.y releases from
+# the upstream Apt repository. To install the latest minor release, set
+# this to e.g. ``2.x``.
 elasticsearch_version: '1.7'
 
 
@@ -162,8 +164,7 @@ elasticsearch_http_enabled: true
 # .. envvar:: elasticsearch_jsonp_enabled
 #
 # Enable JSONP via HTTP. Do not enable this unless you have a very good reason
-# to do so. This feature is deprecated and won't be supported anymore with
-# Elasticsearch 2.x.
+# to do so. This variable is only used with ES 1.x.
 elasticsearch_jsonp_enabled: false
 
 
@@ -206,7 +207,9 @@ elasticsearch_http_allow: []
 # .. envvar:: elasticsearch_gateway_type
 #
 # Gateway type for (re)storing the state of the cluster meta data across full
-# cluster restarts. For more information see `Gateway Module
+# cluster restarts. If an index should not persist its state, set this to
+# ``none``. This variable is only used with ES 1.x. For more information see
+# `Gateway Module
 # <https://www.elastic.co/guide/en/elasticsearch/reference/1.7/modules-gateway.html>`.
 elasticsearch_gateway_type: 'local'
 
@@ -251,7 +254,9 @@ elasticsearch_discovery_ping_timeout: '3s'
 
 # .. envvar:: elasticsearch_discovery_multicast_enabled
 #
-# Whether multicast ping discovery is enabled.
+# Whether multicast ping discovery is enabled. In ES 1.x this feature is
+# supported natively. In ES 2.x the ``discovery-multicast`` plugin will be
+# installed automatically if this feature is enabled.
 elasticsearch_discovery_multicast_enabled: true
 
 
@@ -394,6 +399,7 @@ elasticsearch_logger:
   gateway: 'DEBUG'
   index_gateway: 'DEBUG'
   indices_recovery: 'DEBUG'
+  deprecation: 'DEBUG, deprecation_log_file'
   discovery: 'TRACE'
   index_search_slowlog: 'TRACE, index_search_slow_log_file'
   index_indexing_slowlog: 'TRACE, index_indexing_slow_log_file'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,24 +1,34 @@
 ---
 
 - name: Add Elasticsearch APT key
-  apt_key: url=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
-           id={{ elasticsearch_key_id }}
-           state=present
+  apt_key:
+    url: 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch'
+    id: '{{ elasticsearch_key_id }}'
+    state: present
 
 - name: Add Elasticsearch repository
-  apt_repository: repo='deb {{ elasticsearch_repository }}/{{ elasticsearch_version }}/debian stable main'
-                  state=present update_cache=True
+  apt_repository:
+    repo: 'deb {{ elasticsearch_repository }}/{{ elasticsearch_version if (elasticsearch__version_major | int == 1) else (elasticsearch__version_major + ".x") }}/debian stable main'
+    state: present
+    update_cache: True
 
 - name: Install Elasticsearch
-  apt: pkg=elasticsearch state=present install_recommends=False
+  apt:
+    pkg: 'elasticsearch'
+    state: present
+    install_recommends: False
 
 - name: Divert original configs
   command: dpkg-divert --quiet --local --divert {{ elasticsearch_path_conf }}/{{ item }}.yml.dpkg-divert --rename {{ elasticsearch_path_conf }}/{{ item }}.yml creates={{ elasticsearch_path_conf }}/{{ item }}.yml.dpkg-divert
   with_items: [ 'elasticsearch', 'logging' ]
 
 - name: Configure Elasticsearch
-  template: src={{ item[1:] }}.j2 dest={{ item }}
-            owner=root group=elasticsearch mode=0640
+  template:
+    src: '{{ item[1:] }}.j2'
+    dest: '{{ item }}'
+    owner: 'root'
+    group: 'elasticsearch'
+    mode: '0640'
   with_items:
     - '/etc/default/elasticsearch'
     - '{{ elasticsearch_path_conf }}/elasticsearch.yml'
@@ -26,4 +36,7 @@
   notify: [ 'Restart Elasticsearch' ]
 
 - name: Start Elasticsearch
-  service: name=elasticsearch state=started enabled=True
+  service:
+    name: 'elasticsearch'
+    state: started
+    enabled: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,8 @@
 - include: install.yml
 
 - include: plugins.yml
-  when: elasticsearch_plugins|d([]) | length > 0
+  when: (elasticsearch_plugins|d([]) | length > 0) or
+        (elasticsearch__version_major | int == 2)
 
 - include: libs.yml
   when: elasticsearch_libs|d([]) | length > 0

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -6,30 +6,38 @@
     state: 'directory'
 
 - name: Detect installed plugins
-  shell: bin/plugin -l
+  shell: 'bin/plugin {{ "-l" if (elasticsearch__version_major | int == 1) else "list" }}'
   args:
     chdir: '{{ elasticsearch_path_home }}'
   changed_when: False
   register: elasticsearch_register_installed_plugins
 
 - name: Delete plugins
-  shell: bin/plugin -s -r {{ item.name }}
+  shell: 'bin/plugin {{ "-s -r" if (elasticsearch__version_major | int == 1) else "remove" }} {{ item.name }}'
   args:
     chdir: '{{ elasticsearch_path_home }}'
-  when: item.delete is defined and item.delete and
+  when: ("delete" in item and item.delete) and
         (item.name in elasticsearch_register_installed_plugins.stdout or
-        item.name.split('/')[1] in elasticsearch_register_installed_plugins.stdout)
-  with_items: '{{ elasticsearch_plugins }}'
+         item.name.split('/')[1] in elasticsearch_register_installed_plugins.stdout)
+  with_flattened:
+    - '{{ elasticsearch_plugins }}'
+    - '{{ [ { "name": "discovery-multicast", "delete": True } ]
+          if ((elasticsearch__version_major | int == 2) and not elasticsearch_discovery_multicast_enabled|d(False))
+          else [] }}'
   notify: [ 'Restart Elasticsearch' ]
 
 - name: Install plugins by name
-  shell: bin/plugin -i {{ item.name }}
+  shell: 'bin/plugin {{ "-i" if (elasticsearch__version_major | int == 1) else "install" }} {{ item.name }}'
   args:
     chdir: '{{ elasticsearch_path_home }}'
   when: (item.url is undefined or not item.url) and
         (item.delete is undefined or not item.delete) and
         not item.name.split('/')[1] in elasticsearch_register_installed_plugins.stdout
-  with_items: '{{ elasticsearch_plugins }}'
+  with_flattened:
+    - '{{ elasticsearch_plugins }}'
+    - '{{ [ { "name": "discovery-multicast" } ]
+          if ((elasticsearch__version_major | int == 2) and elasticsearch_discovery_multicast_enabled|d(False))
+          else [] }}'
   notify: [ 'Restart Elasticsearch' ]
 
 - name: Install plugins by url

--- a/templates/etc/elasticsearch/elasticsearch.yml.j2
+++ b/templates/etc/elasticsearch/elasticsearch.yml.j2
@@ -1,438 +1,202 @@
-##################### Elasticsearch Configuration Example #####################
-
-# This file contains an overview of various configuration settings,
-# targeted at operations staff. Application developers should
-# consult the guide at <http://elasticsearch.org/guide>.
+# {{ ansible_managed }}
+{#
+# ======================== Elasticsearch Configuration =========================
 #
-# The installation procedure is covered at
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html>.
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
 #
-# Elasticsearch comes with reasonable defaults for most settings,
-# so you can try it out without bothering with configuration.
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
 #
-# Most of the time, these defaults are just fine for running a production
-# cluster. If you're fine-tuning your cluster, or wondering about the
-# effect of certain configuration option, please _do ask_ on the
-# mailing list or IRC channel [http://elasticsearch.org/community].
-
-# Any element in the configuration can be replaced with environment variables
-# by placing them in ${...} notation. For example:
+# Please see the documentation for further information on configuration options:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html>
+#}
+# ---------------------------------- Cluster -----------------------------------
+{#
+# Use a descriptive name for your cluster:
 #
-#node.rack: ${RACK_ENV_VAR}
-
-# For information on supported formats and syntax for the config file, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup-configuration.html>
-
-################################### Cluster ###################################
-
-# Cluster name identifies your cluster for auto-discovery. If you're running
-# multiple clusters on the same network, make sure you're using unique names.
-#
+# cluster.name: my-application
+#}
 cluster.name: {{ elasticsearch_cluster_name }}
 
-#################################### Node #####################################
-
-# Node names are generated dynamically on startup, so you're relieved
-# from configuring them manually. You can tie this node to a specific name:
-#
-#node.name: "Franz Kafka"
+# ------------------------------------ Node ------------------------------------
+{#
+# Use a descriptive name for the node:
+#}
 {% if elasticsearch_node_name %}
 node.name: {{ elasticsearch_node_name }}
 {% endif %}
-
-# Every node can be configured to allow or deny being eligible as the master,
-# and to allow or deny to store the data.
 {% if elasticsearch_group_workhorse in group_names %}
-# 1. You want this node to never become a master node, only to hold data.
-#    This will be the "workhorse" of your cluster.
 node.master: false
 node.data: true
 {% elif elasticsearch_group_coordinator in group_names %}
-# 2. You want this node to only serve as a master: to not store any data and
-#    to have free resources. This will be the "coordinator" of your cluster.
 node.master: true
 node.data: false
 {% elif elasticsearch_group_loadbalancer in group_names %}
-# 3. You want this node to be neither master nor data node, but
-#    to act as a "search load balancer" (fetching data from nodes,
-#    aggregating results, etc.)
 node.master: false
 node.data: false
 {% else %}
-# If it is not in any of the above sub-groups then we want a master.
 node.master: true
 node.data: true
 {% endif %}
-
-# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
-# Node Info API [http://localhost:9200/_nodes] or GUI tools
-# such as <http://www.elasticsearch.org/overview/marvel/>,
-# <http://github.com/karmi/elasticsearch-paramedic>,
-# <http://github.com/lukas-vlcek/bigdesk> and
-# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
-
-# A node can have generic attributes associated with it, which can later be used
-# for customized shard allocation filtering, or allocation awareness. An attribute
-# is a simple key value pair, similar to node.key: value, here is an example:
-#
-#node.rack: rack314
+{#
+# Add custom attributes to the node:
+#}
 node.rack: {{ elasticsearch_node_rack }}
 
-# By default, multiple nodes are allowed to start from the same installation location
-# to disable it, set the following:
-#node.max_local_storage_nodes: 1
-node.max_local_storage_nodes: {{ elasticsearch_node_max_local_storage_nodes }}
+# ----------------------------------- Paths ------------------------------------
+{#
+# Path to directory where to store the data (separate multiple locations by comma):
+#}
+path.data: {{ elasticsearch_path_data }}
+{#
+# Path to log files:
+#}
+path.logs: {{ elasticsearch_path_logs }}
+{% if elasticsearch__version_major == 1 %}
+path.conf: {{ elasticsearch_path_conf }}
+path.work: {{ elasticsearch_path_work }}
+path.plugins: {{ elasticsearch_path_plugins }}
+{% endif %}
 
-#################################### Index ####################################
+# ----------------------------------- Memory -----------------------------------
+{#
+# Lock the memory on startup:
+#}
+{% if elasticsearch__version_major == 1 %}
+bootstrap.mlockall: {{ elasticsearch_memory_mlockall | lower }}
+{% else %}
+bootstrap.memory_lock: {{ elasticsearch_memory_mlockall | lower }}
+{% endif %}
+{#
+# Make sure that the `ES_HEAP_SIZE` environment variable is set to about half the memory
+# available on the system and that the owner of the process is allowed to use this limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#}
 
-# You can set a number of options (such as shard/replica options, mapping
-# or analyzer definitions, translog settings, ...) for indices globally,
-# in this file.
-#
-# Note, that it makes more sense to configure index settings specifically for
-# a certain index, either when creating it or by using the index templates API.
-#
-# See <http://elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules.html> and
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html>
-# for more information.
+# ---------------------------------- Network -----------------------------------
+{#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#}
+network.bind_host: {{ elasticsearch_bind_host }}
+network.publish_host: {{ elasticsearch_publish_host }}
+transport.tcp.port: {{ elasticsearch_node_port }}
+transport.tcp.compress: {{ elasticsearch_compress | lower }}
+http.enabled: {{ elasticsearch_http_enabled | lower }}
+{#
+# Set a custom port for HTTP:
+#}
+{% if elasticsearch_http_enabled %}
+http.port: {{ elasticsearch_http_port }}
+http.max_content_length: {{ elasticsearch_http_max_content_length }}
+{% endif %}
+{#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
+#}
 
-# Set the number of shards (splits) of an index (5 by default):
-#
-#index.number_of_shards: 5
+# --------------------------------- Discovery ----------------------------------
+{#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#}
+{% if elasticsearch_discovery_ping_unicast_hosts|d([]) or
+      ((elasticsearch__version_major | int == 2) and (elasticsearch_discovery_multicast_enabled|d(False))) %}
+discovery.zen.ping.unicast.hosts: {{ elasticsearch_discovery_ping_unicast_hosts|d([]) }}
+{% endif %}
+discovery.zen.ping.timeout: {{ elasticsearch_discovery_ping_timeout }}
+{% if (elasticsearch__version_major | int == 1) or (elasticsearch_discovery_multicast_enabled|d(False)) %}
+discovery.zen.ping.multicast.enabled: {{ elasticsearch_discovery_multicast_enabled | lower }}
+discovery.zen.ping.multicast.port: {{ elasticsearch_discovery_multicast_port }}
+{% endif %}
+{#
+# Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
+#}
+discovery.zen.minimum_master_nodes: {{ elasticsearch_discovery_minimum_master_nodes }}
+{#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+#}
 
-# Set the number of replicas (additional copies) of an index (1 by default):
-#
-#index.number_of_replicas: 1
+# ---------------------------------- Gateway -----------------------------------
+{#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#}
+{% if elasticsearch_gateway_recover_after_nodes|d(False) %}
+gateway.recover_after_nodes: {{ elasticsearch_gateway_recover_after_nodes }}
+{% endif %}
+{% if elasticsearch_gateway_recover_after_time|d(False) %}
+gateway.recover_after_time: {{ elasticsearch_gateway_recover_after_time }}
+{% endif %}
+{% if elasticsearch_gateway_expected_nodes|d(False) %}
+gateway.expected_nodes: {{ elasticsearch_gateway_expected_nodes }}
+{% endif %}
+{% if elasticsearch__version_major | int == 1 %}
+gateway.type: {{ elasticsearch_gateway_type }}
+{% endif %}
+{#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
+#}
 
-# Note, that for development on a local machine, with small indices, it usually
-# makes sense to "disable" the distributed features:
-#
-#index.number_of_shards: 1
-#index.number_of_replicas: 0
-
-# These settings directly affect the performance of index and search operations
-# in your cluster. Assuming you have enough machines to hold shards and
-# replicas, the rule of thumb is:
-#
-# 1. Having more *shards* enhances the _indexing_ performance and allows to
-#    _distribute_ a big index across machines.
-# 2. Having more *replicas* enhances the _search_ performance and improves the
-#    cluster _availability_.
-#
-# The "number_of_shards" is a one-time setting for an index.
-#
-# The "number_of_replicas" can be increased or decreased anytime,
-# by using the Index Update Settings API.
-#
-# Elasticsearch takes care about load balancing, relocating, gathering the
-# results from nodes, etc. Experiment with different settings to fine-tune
-# your setup.
-
-# Use the Index Status API (<http://localhost:9200/A/_status>) to inspect
-# the index status.
+# ---------------------------------- Indices -----------------------------------
 index.number_of_shards: {{ elasticsearch_index_shards }}
 index.number_of_replicas: {{ elasticsearch_index_replicas }}
 
-#################################### Paths ####################################
-
-# Path to directory containing configuration (this file and logging.yml):
-#
-#path.conf: /path/to/conf
-path.conf: {{ elasticsearch_path_conf }}
-
-# Path to directory where to store index data allocated for this node.
-#
-#path.data: /path/to/data
-#
-# Can optionally include more than one location, causing data to be striped across
-# the locations (a la RAID 0) on a file level, favouring locations with most free
-# space on creation. For example:
-#
-#path.data: /path/to/data1,/path/to/data2
-path.data: {{ elasticsearch_path_data }}
-
-# Path to temporary files:
-#
-#path.work: /path/to/work
-path.work: {{ elasticsearch_path_work }}
-
-# Path to log files:
-#
-#path.logs: /path/to/logs
-path.logs: {{ elasticsearch_path_logs }}
-
-# Path to where plugins are installed:
-#
-#path.plugins: /path/to/plugins
-path.plugins: {{ elasticsearch_path_plugins }}
-
-#################################### Plugin ###################################
-
-# If a plugin listed here is not installed for current node, the node will not start.
-#
-#plugin.mandatory: mapper-attachments,lang-groovy
-
-################################### Memory ####################################
-
-# Elasticsearch performs poorly when JVM starts swapping: you should ensure that
-# it _never_ swaps.
-#
-# Set this property to true to lock the memory:
-#
-#bootstrap.mlockall: true
-bootstrap.mlockall: {{ elasticsearch_memory_mlockall | lower }}
-
-# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
-# to the same value, and that the machine has enough memory to allocate
-# for Elasticsearch, leaving enough memory for the operating system itself.
-#
-# You should also make sure that the Elasticsearch process is allowed to lock
-# the memory, eg. by using `ulimit -l unlimited`.
-
-############################## Network And HTTP ###############################
-
-# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
-# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
-# communication. (the range means that if the port is busy, it will automatically
-# try the next port).
-
-# Set the bind address specifically (IPv4 or IPv6):
-#
-#network.bind_host: 192.168.0.1
-network.bind_host: {{ elasticsearch_bind_host }}
-
-# Set the address other nodes will use to communicate with this node. If not
-# set, it is automatically derived. It must point to an actual IP address.
-#
-#network.publish_host: 192.168.0.1
-network.publish_host: {{ elasticsearch_publish_host }}
-
-# Set a custom port for the node to node communication (9300 by default):
-#
-#transport.tcp.port: 9300
-transport.tcp.port: {{ elasticsearch_node_port }}
-
-# Enable compression for all communication between nodes (disabled by default):
-#
-#transport.tcp.compress: true
-transport.tcp.compress: {{ elasticsearch_compress | lower }}
-
-# Set a custom port to listen for HTTP traffic:
-#
-#http.port: 9200
-http.port: {{ elasticsearch_http_port }}
-
-# Set a custom allowed content length:
-#
-#http.max_content_length: 100mb
-http.max_content_length: {{ elasticsearch_http_max_content_length }}
-
-# Disable HTTP completely:
-#
-#http.enabled: false
-http.enabled: {{ elasticsearch_http_enabled | lower }}
-
-################################### Gateway ###################################
-
-# The gateway allows for persisting the cluster state between full cluster
-# restarts. Every change to the state (such as adding an index) will be stored
-# in the gateway, and when the cluster starts up for the first time,
-# it will read its state from the gateway.
-
-# There are several types of gateway implementations. For more information, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-gateway.html>.
-
-# The default gateway type is the "local" gateway (recommended):
-#
-#gateway.type: local
-gateway.type: {{ elasticsearch_gateway_type }}
-
-# Settings below control how and when to start the initial recovery process on
-# a full cluster restart (to reuse as much local data as possible when using shared
-# gateway).
-
-# Allow recovery process after N nodes in a cluster are up:
-#
-#gateway.recover_after_nodes: 1
-{% if elasticsearch_gateway_recover_after_nodes is defined and elasticsearch_gateway_recover_after_nodes %}
-gateway.recover_after_nodes: {{ elasticsearch_gateway_recover_after_nodes }}
-{% endif %}
-
-# Set the timeout to initiate the recovery process, once the N nodes
-# from previous setting are up (accepts time value):
-#
-#gateway.recover_after_time: 5m
-{% if elasticsearch_gateway_recover_after_time is defined and elasticsearch_gateway_recover_after_time %}
-gateway.recover_after_time: {{ elasticsearch_gateway_recover_after_time }}
-{% endif %}
-
-# Set how many nodes are expected in this cluster. Once these N nodes
-# are up (and recover_after_nodes is met), begin recovery process immediately
-# (without waiting for recover_after_time to expire):
-#
-#gateway.expected_nodes: 2
-{% if elasticsearch_gateway_expected_nodes is defined and elasticsearch_gateway_expected_nodes %}
-gateway.expected_nodes: {{ elasticsearch_gateway_expected_nodes }}
-{% endif %}
-
-############################# Recovery Throttling #############################
-
-# These settings allow to control the process of shards allocation between
-# nodes during initial recovery, replica allocation, rebalancing,
-# or when adding and removing nodes.
-
-# Set the number of concurrent recoveries happening on a node:
-#
-# 1. During the initial recovery
-#
-#cluster.routing.allocation.node_initial_primaries_recoveries: 4
-{% if elasticsearch_recovery_node_initial_primaries_recoveries is defined and elasticsearch_recovery_node_initial_primaries_recoveries %}
-cluster.routing.allocation.node_install_primaries_recoveries: {{ elasticsearch_recovery_node_initial_primaries_recoveries }}
-{% endif %}
-
-#
-# 2. During adding/removing nodes, rebalancing, etc
-#
-#cluster.routing.allocation.node_concurrent_recoveries: 2
-{% if elasticsearch_recovery_node_concurrent_recoveries is defined and elasticsearch_recovery_node_concurrent_recoveries %}
+# ---------------------------------- Recovery ----------------------------------
+{% if elasticsearch_recovery_node_concurrent_recoveries|d(False) %}
 cluster.routing.allocation.node_concurrent_recoveries: {{ elasticsearch_recovery_node_concurrent_recoveries }}
 {% endif %}
-
-# Set to throttle throughput when recovering (eg. 100mb, by default 20mb):
-#
-#indices.recovery.max_bytes_per_sec: 20mb
+{% if elasticsearch_recovery_node_initial_primaries_recoveries|d(False) %}
+cluster.routing.allocation.node_install_primaries_recoveries: {{ elasticsearch_recovery_node_initial_primaries_recoveries }}
+{% endif %}
 indicies.recovery.max_bytes_per_sec: {{ elasticsearch_recovery_max_bytes_per_sec }}
-
-# Set to limit the number of open concurrent streams when
-# recovering a shard from a peer:
-#
-#indices.recovery.concurrent_streams: 5
-{% if elasticsearch_recovery_concurrent_streams is defined and elasticsearch_recovery_concurrent_streams %}
+{% if elasticsearch_recovery_concurrent_streams|d(False) %}
 indicies.recovery.concurrent_streams: {{ elasticsearch_recovery_concurrent_streams }}
 {% endif %}
 
-################################## Discovery ##################################
-
-# Discovery infrastructure ensures nodes can be found within a cluster
-# and master node is elected. Multicast discovery is the default.
-
-# Set to ensure a node sees N other master eligible nodes to be considered
-# operational within the cluster. Its recommended to set it to a higher value
-# than 1 when running more than 2 nodes in the cluster.
+# ---------------------------------- Various -----------------------------------
+{#
+# Disable starting multiple nodes on a single system:
+#}
+node.max_local_storage_nodes: {{ elasticsearch_node_max_local_storage_nodes }}
+{#
+# Require explicit names when deleting indices:
 #
-#discovery.zen.minimum_master_nodes: 1
-{% if elasticsearch_discovery_minimum_master_nodes is defined and elasticsearch_discovery_minimum_master_nodes %}
-discovery.zen.minimum_master_nodes: {{ elasticsearch_discovery_minimum_master_nodes }}
+# action.destructive_requires_name: true
+#}
+{% if elasticsearch__version_major | int == 1 %}
+http.jsonp.enable: {{ elasticsearch_jsonp_enabled | lower }}
 {% endif %}
 
-# Set the time to wait for ping responses from other nodes when discovering.
-# Set this option to a higher value on a slow or congested network
-# to minimize discovery failures:
-#
-#discovery.zen.ping.timeout: 3s
-discovery.zen.ping.timeout: {{ elasticsearch_discovery_ping_timeout }}
-
-# For more information, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>
-
-# Unicast discovery allows to explicitly control which nodes will be used
-# to discover the cluster. It can be used when multicast is not present,
-# or to restrict the cluster communication-wise.
-#
-# 1. Disable multicast discovery (enabled by default):
-#
-#discovery.zen.ping.multicast.enabled: false
-discovery.zen.ping.multicast.enabled: {{ elasticsearch_discovery_multicast_enabled | lower }}
-
-#
-# 2. Configure an initial list of master nodes in the cluster
-#    to perform discovery when new nodes (master or data) are started:
-#
-#discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
-{% if elasticsearch_discovery_ping_unicast_hosts %}
-discovery.zen.ping.unicast.hosts: {{ elasticsearch_discovery_ping_unicast_hosts }}
-{% endif %}
-
-# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
-#
-# You have to install the cloud-aws plugin for enabling the EC2 discovery.
-#
-# For more information, see
-# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-ec2.html>
-#
-# See <http://elasticsearch.org/tutorials/elasticsearch-on-ec2/>
-# for a step-by-step tutorial.
-
-# GCE discovery allows to use Google Compute Engine API in order to perform discovery.
-#
-# You have to install the cloud-gce plugin for enabling the GCE discovery.
-#
-# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-gce>.
-
-# Azure discovery allows to use Azure API in order to perform discovery.
-#
-# You have to install the cloud-azure plugin for enabling the Azure discovery.
-#
-# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
-
-################################## Slow Log ##################################
-
-# Shard level query and fetch threshold logging.
-
-#index.search.slowlog.threshold.query.warn: 10s
-#index.search.slowlog.threshold.query.info: 5s
-#index.search.slowlog.threshold.query.debug: 2s
-#index.search.slowlog.threshold.query.trace: 500ms
+# --------------------------------- Slow Log -----------------------------------
 index.search.slowlog.threshold.query.warn: {{ elasticsearch_slowlog_query_warn }}
 index.search.slowlog.threshold.query.info: {{ elasticsearch_slowlog_query_info }}
 index.search.slowlog.threshold.query.debug: {{ elasticsearch_slowlog_query_debug }}
 index.search.slowlog.threshold.query.trace: {{ elasticsearch_slowlog_query_trace }}
 
-#index.search.slowlog.threshold.fetch.warn: 1s
-#index.search.slowlog.threshold.fetch.info: 800ms
-#index.search.slowlog.threshold.fetch.debug: 500ms
-#index.search.slowlog.threshold.fetch.trace: 200ms
 index.search.slowlog.threshold.fetch.warn: {{ elasticsearch_slowlog_fetch_warn }}
 index.search.slowlog.threshold.fetch.info: {{ elasticsearch_slowlog_fetch_info }}
 index.search.slowlog.threshold.fetch.debug: {{ elasticsearch_slowlog_fetch_debug }}
 index.search.slowlog.threshold.fetch.trace: {{ elasticsearch_slowlog_fetch_trace }}
 
-#index.indexing.slowlog.threshold.index.warn: 10s
-#index.indexing.slowlog.threshold.index.info: 5s
-#index.indexing.slowlog.threshold.index.debug: 2s
-#index.indexing.slowlog.threshold.index.trace: 500ms
 index.search.slowlog.threshold.index.warn: {{ elasticsearch_slowlog_index_warn }}
 index.search.slowlog.threshold.index.info: {{ elasticsearch_slowlog_index_info }}
 index.search.slowlog.threshold.index.debug: {{ elasticsearch_slowlog_index_debug }}
 index.search.slowlog.threshold.index.trace: {{ elasticsearch_slowlog_index_trace }}
 
-################################## GC Logging ################################
-
-#monitor.jvm.gc.young.warn: 1000ms
-#monitor.jvm.gc.young.info: 700ms
-#monitor.jvm.gc.young.debug: 400ms
+# -------------------------------- GC Logging ----------------------------------
 monitor.jvm.gc.young.warn: {{ elasticsearch_monitor_gc_young_warn }}
 monitor.jvm.gc.young.info: {{ elasticsearch_monitor_gc_young_info }}
 monitor.jvm.gc.young.debug: {{ elasticsearch_monitor_gc_young_debug }}
 
-#monitor.jvm.gc.old.warn: 10s
-#monitor.jvm.gc.old.info: 5s
-#monitor.jvm.gc.old.debug: 2s
 monitor.jvm.gc.old.warn: {{ elasticsearch_monitor_gc_old_warn }}
 monitor.jvm.gc.old.info: {{ elasticsearch_monitor_gc_old_info }}
 monitor.jvm.gc.old.debug: {{ elasticsearch_monitor_gc_old_debug }}
 
-################################## Security ################################
-
-# Uncomment if you want to enable JSONP as a valid return transport on the
-# http server. With this enabled, it may pose a security risk, so disabling
-# it unless you need it is recommended (it is disabled by default).
-#
-#http.jsonp.enable: true
-http.jsonp.enable: {{ elasticsearch_jsonp_enabled | lower }}
-
-############################### Plugin configs #############################
-
+# -------------------------------- Plugin configs ------------------------------
 {% if elasticsearch_plugins %}
 {% for item in elasticsearch_plugins %}
 {% if (item.delete is undefined or not item.delete) and (item.config is defined and item.config) %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,11 @@ elasticsearch_key_id: 'D88E42B4'
 elasticsearch_repository: 'http://packages.elastic.co/elasticsearch'
 
 
+# --- Version ---
+
+elasticsearch__version_major: '{{ (elasticsearch_version | string).split(".")[0] | int }}'
+
+
 # --- Paths ---
 
 elasticsearch_path_conf: '/etc/elasticsearch'


### PR DESCRIPTION
This PR will add support for Elasticsearch 2.x. The changes mainly consist of `elasticsearch.yml` template updates and fixes regarding the repository path and plugin installation. This PR fixes #9.

I further adjusted the default value for `elasticsearch_node_max_local_storage_nodes` which didn't make sense to me. @nickjj: some explanation for this?

@drybjed: I would suggest if this PR is merged, you tag a release, so that people using this role still have a compatible version to refer to. Afterwards I will completely restructure the configuration variables, to be more flexible and allow most upstream configuration variables to be set.